### PR TITLE
Ignore PDFs

### DIFF
--- a/urlpreview/base-config.yaml
+++ b/urlpreview/base-config.yaml
@@ -8,6 +8,7 @@ max_image_embed: 300
 no_results_react: 💨
 url_blacklist:
   - ':\/\/matrix\.to\/'
+  - '\.pdf'
   - '0.0.0.0'
   - '1.0.0.0/8'
   - '127.0.0.0/8'

--- a/urlpreview/maubot.yaml
+++ b/urlpreview/maubot.yaml
@@ -1,6 +1,6 @@
 maubot: 0.1.0
 id: coffee.maubot.urlpreview
-version: 0.3.3.20
+version: 0.3.3.20.1
 license: AGPL-3.0-or-later
 modules:
 - urlpreview

--- a/urlpreview/urlpreview/urlpreview.py
+++ b/urlpreview/urlpreview/urlpreview.py
@@ -92,11 +92,12 @@ class UrlPreviewBot(Plugin):
             max_count += 1
 
         if len(embeds) <= 0:
-            if NO_RESULTS_REACT:
-                try:
-                    await evt.react(NO_RESULTS_REACT)
-                except: # Silently ignore if react doesn't work
-                    pass
+            if count > 0:
+                if NO_RESULTS_REACT:
+                    try:
+                        await evt.react(NO_RESULTS_REACT)
+                    except: # Silently ignore if react doesn't work
+                        pass
             return
         to_send = "".join(embeds)
         return await evt.reply(to_send, allow_html=True)


### PR DESCRIPTION
PDFs can't be previewed, so they should be blacklisted by default.