### PR TITLE
urlpreview: add html_custom_headers

### DIFF
--- a/urlpreview/base-config.yaml
+++ b/urlpreview/base-config.yaml
@@ -1,6 +1,7 @@
 ext_enabled: ["json", "synapse", "htmlparser"]
 appid: BOT_ACCESS_TOKEN
 homeserver: matrix-client.matrix.org
+html_custom_headers: {}
 json_max_char: 2000
 max_links: 3
 min_image_width: 475

--- a/urlpreview/urlpreview/urlpreview.py
+++ b/urlpreview/urlpreview/urlpreview.py
@@ -25,6 +25,7 @@ class Config(BaseProxyConfig):
         helper.copy("ext_enabled")
         helper.copy("appid")
         helper.copy("homeserver")
+        helper.copy("html_custom_headers")
         helper.copy("json_max_char")
         helper.copy("max_links")
         helper.copy("min_image_width")
@@ -54,6 +55,7 @@ class UrlPreviewBot(Plugin):
         appid = self.config["appid"]
         MAX_LINKS = self.config["max_links"]
         HOMESERVER = self.config["homeserver"]
+        HTML_CUSTOM_HEADERS = self.config["html_custom_headers"]
         JSON_MAX_CHAR = self.config["json_max_char"]
         MIN_IMAGE_WIDTH = self.config["min_image_width"]
         MAX_IMAGE_EMBED = self.config["max_image_embed"]
@@ -82,6 +84,7 @@ class UrlPreviewBot(Plugin):
                 "ext_enabled": EXT_ENABLED,
                 "appid": appid,
                 "homeserver": HOMESERVER,
+                "html_custom_headers": HTML_CUSTOM_HEADERS,
                 "json_max_char": JSON_MAX_CHAR
             }
             og = await fetch_all(**arg_arr)
@@ -110,6 +113,7 @@ async def fetch_all(
         ext_enabled=EXT_FALLBACK,
         appid: str='BOT_ACCESS_TOKEN',
         homeserver: str='matrix-client.matrix.org',
+        html_custom_headers={},
         json_max_char=2000,
         **kwargs
     ):
@@ -122,6 +126,7 @@ async def fetch_all(
                 "url_str": url_str,
                 "appid": appid,
                 "homeserver": homeserver,
+                "html_custom_headers": html_custom_headers,
                 "json_max_char": json_max_char
             }
             og_resp = await fetch_ext(**arg_arr)

--- a/urlpreview/urlpreview/urlpreview_ext_htmlparser.py
+++ b/urlpreview/urlpreview/urlpreview_ext_htmlparser.py
@@ -6,12 +6,12 @@ from urllib.parse import urlparse
 
 from .urlpreview_utils import *
 
-async def fetch_htmlparser(self, url_str, **kwargs):
+async def fetch_htmlparser(self, url_str, html_custom_headers, **kwargs):
     if not url_str:
         return None
 
     try:
-        resp = await self.http.get(url_str, timeout=30) # 30s timeout matches Matrix Synapse
+        resp = await self.http.get(url_str, timeout=30, headers=html_custom_headers) # 30s timeout matches Matrix Synapse
     except Exception as err:
         self.log.exception(f"[urlpreview] [ext_htmlparser] Error: {str(err)} - {str(urlparse(url_str).netloc)}")
         return None


### PR DESCRIPTION
Adds config option to set custom headers for HTML parser.

If the headers are not set (`{}`), default aiohttp headers are used, so e.g. the user agent was `Python/3.11 aiohttp/3.8.5`.

In my case, I need to use `{ Accept-Encoding: 'deflate, gzip, br, zstd', User-Agent: 'WhatsApp/2' }` to get `og:*` tags instead of 403 and a captcha on links to https://allegro.pl. The user agent was borrowed from Signal, where previews are generated on client side and work as intended: https://github.com/signalapp/Signal-Android/issues/9958

`matrix_get_image` and `check_image_content_type` still use the default headers. That's ok for the few websites I've checked, but do you think those functions should use custom headers, same as HTML parser?

