### PR TITLE
Fix no results reaction

### DIFF
--- a/urlpreview/urlpreview/urlpreview.py
+++ b/urlpreview/urlpreview/urlpreview.py
@@ -95,7 +95,7 @@ class UrlPreviewBot(Plugin):
             max_count += 1
 
         if len(embeds) <= 0:
-            if count > 0 and NO_RESULTS_REACT:
+            if len(matches) > 0 and NO_RESULTS_REACT:
                 try:
                     await evt.react(NO_RESULTS_REACT)
                 except: # Silently ignore if react doesn't work


### PR DESCRIPTION
The variable `count` only increases when an embed was found, so this statement would've never been able to trigger.

I changed it to `len(matches)` as this should be intended check, to only show the reaction if there were URLs in the message, but no embeds were found.